### PR TITLE
Use CryptoConfig to configure arrays

### DIFF
--- a/benchmarks/src/com/facebook/crypto/benchmarks/cipher/NativeGCMCipherHelper.java
+++ b/benchmarks/src/com/facebook/crypto/benchmarks/cipher/NativeGCMCipherHelper.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.SecureRandom;
 
+import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.benchmarks.BenchmarkNativeCryptoLibrary;
 import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.util.NativeCryptoLibrary;
@@ -27,20 +28,22 @@ public class NativeGCMCipherHelper {
   private static final NativeCryptoLibrary mNativeCryptoLibrary =
       new BenchmarkNativeCryptoLibrary();
 
-  private byte[] mKey;
-  private byte[] mIv;
+  private final byte[] mKey;
+  private final byte[] mIv;
+  private final int mTagLength;
 
-  public NativeGCMCipherHelper(byte[] key, byte[] iv) {
+  public NativeGCMCipherHelper(byte[] key, byte[] iv, int tagLength) {
     this.mKey = key.clone();
     this.mIv = iv.clone();
+    mTagLength = tagLength;
   }
 
   public static NativeGCMCipherHelper getInstance() {
-    byte[] key = new byte[NativeGCMCipher.KEY_LENGTH];
-    byte[] iv = new byte[NativeGCMCipher.IV_LENGTH];
+    byte[] key = new byte[CryptoConfig.KEY_128.keyLength];
+    byte[] iv = new byte[CryptoConfig.KEY_128.ivLength];
     new SecureRandom().nextBytes(key);
     new SecureRandom().nextBytes(iv);
-    return new NativeGCMCipherHelper(key, iv);
+    return new NativeGCMCipherHelper(key, iv, CryptoConfig.KEY_128.tagLength);
   }
 
   public OutputStream getOutputStream(OutputStream cipherStream, byte[] encryptBuffer)
@@ -49,16 +52,16 @@ public class NativeGCMCipherHelper {
     gcmCipher.encryptInit(mKey, mIv);
     cipherStream.write(mIv);
 
-    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher, encryptBuffer);
+    return new NativeGCMCipherOutputStream(cipherStream, gcmCipher, encryptBuffer, mTagLength);
   }
 
   public InputStream getInputStream(InputStream cipherStream)
       throws IOException, CryptoInitializationException {
-    byte[] iv = new byte[NativeGCMCipher.IV_LENGTH];
+    byte[] iv = new byte[CryptoConfig.KEY_128.ivLength];
     cipherStream.read(iv);
     NativeGCMCipher gcmCipher = new NativeGCMCipher(mNativeCryptoLibrary);
     gcmCipher.decryptInit(mKey, iv);
 
-    return new NativeGCMCipherInputStream(cipherStream, gcmCipher);
+    return new NativeGCMCipherInputStream(cipherStream, gcmCipher, mTagLength);
   }
 }

--- a/instrumentTest/crypto/src/com/facebook/crypto/BouncyCastleHelper.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/BouncyCastleHelper.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import android.annotation.TargetApi;
 import android.os.Build;
 
-import com.facebook.crypto.cipher.NativeGCMCipher;
-
 import org.spongycastle.crypto.InvalidCipherTextException;
 import org.spongycastle.crypto.engines.AESEngine;
 import org.spongycastle.crypto.modes.GCMBlockCipher;
@@ -30,13 +28,13 @@ public class BouncyCastleHelper {
   public static Result bouncyCastleEncrypt(byte[] data, byte[] key, byte[] iv, byte[] aadData)
       throws UnsupportedEncodingException, InvalidCipherTextException {
     GCMBlockCipher gcm = new GCMBlockCipher(new AESEngine());
-    byte[] gcmOut = new byte[CryptoTestUtils.NUM_DATA_BYTES + NativeGCMCipher.TAG_LENGTH];
+    byte[] gcmOut = new byte[CryptoTestUtils.NUM_DATA_BYTES + CryptoConfig.KEY_128.tagLength];
     KeyParameter keyParameter = new KeyParameter(key);
 
     // Add aad data.
     AEADParameters params = new AEADParameters(
           keyParameter,
-          NativeGCMCipher.TAG_LENGTH * 8,
+          CryptoConfig.KEY_128.tagLength * 8,
           iv,
           aadData);
 

--- a/instrumentTest/crypto/src/com/facebook/crypto/CryptoSerializerHelper.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/CryptoSerializerHelper.java
@@ -10,8 +10,6 @@
 
 package com.facebook.crypto;
 
-import com.facebook.crypto.cipher.NativeGCMCipher;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -23,20 +21,20 @@ public class CryptoSerializerHelper {
 
   public static byte[] cipherText(byte[] cipheredData) {
     return Arrays.copyOfRange(cipheredData,
-        NativeGCMCipher.IV_LENGTH + 2,
-        cipheredData.length - NativeGCMCipher.TAG_LENGTH);
+        CryptoConfig.KEY_128.ivLength + 2,
+        cipheredData.length - CryptoConfig.KEY_128.tagLength);
   }
 
   public static byte[] tag(byte[] cipheredData) {
     return Arrays.copyOfRange(cipheredData,
-        cipheredData.length - NativeGCMCipher.TAG_LENGTH,
+        cipheredData.length - CryptoConfig.KEY_128.tagLength,
         cipheredData.length);
   }
 
   public static byte[] createCipheredData(byte[] iv, byte[] cipherText, byte[] tag) throws IOException {
     ByteArrayOutputStream cipheredData = new ByteArrayOutputStream();
     cipheredData.write(VersionCodes.CIPHER_SERIALIZATION_VERSION);
-    cipheredData.write(VersionCodes.CIPHER_ID);
+    cipheredData.write(CryptoConfig.KEY_128.cipherId);
     cipheredData.write(iv);
     cipheredData.write(cipherText);
     cipheredData.write(tag);

--- a/instrumentTest/crypto/src/com/facebook/crypto/FakeKeyChain.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/FakeKeyChain.java
@@ -12,14 +12,13 @@ package com.facebook.crypto;
 
 import java.util.Arrays;
 
-import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.keychain.KeyChain;
 import com.facebook.crypto.mac.NativeMac;
 
 public class FakeKeyChain implements KeyChain {
 
-  private final byte[] mKey = new byte[NativeGCMCipher.KEY_LENGTH];
-  private final byte[] mIV = new byte[NativeGCMCipher.IV_LENGTH];
+  private final byte[] mKey = new byte[CryptoConfig.KEY_128.keyLength];
+  private final byte[] mIV = new byte[CryptoConfig.KEY_128.ivLength];
   private final byte[] mMacKey = new byte[NativeMac.KEY_LENGTH];
 
   public FakeKeyChain() {

--- a/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherInputStreamTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherInputStreamTest.java
@@ -18,7 +18,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Random;
 
-import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.cipher.NativeGCMCipherException;
 import com.facebook.crypto.keychain.KeyChain;
 import com.facebook.crypto.util.NativeCryptoLibrary;
@@ -90,15 +89,15 @@ public class NativeGCMCipherInputStreamTest extends InstrumentationTestCase {
   }
 
   public void testDecryptionFailsOnIncorrectTag() throws Exception {
-    byte[] fakeTag = new byte[NativeGCMCipher.TAG_LENGTH];
+    byte[] fakeTag = new byte[CryptoConfig.KEY_128.tagLength];
     Arrays.fill(fakeTag, (byte) CryptoTestUtils.KEY_BYTES);
 
     // Overwrite the tag bytes.
     System.arraycopy(fakeTag,
         0,
         mCipheredData,
-        mCipheredData.length - NativeGCMCipher.TAG_LENGTH,
-        NativeGCMCipher.TAG_LENGTH);
+        mCipheredData.length - CryptoConfig.KEY_128.tagLength,
+            CryptoConfig.KEY_128.tagLength);
 
     InputStream inputStream = null;
     try {
@@ -177,7 +176,7 @@ public class NativeGCMCipherInputStreamTest extends InstrumentationTestCase {
         new Entity(CryptoTestUtils.ENTITY_NAME));
 
     ByteArrayOutputStream decryptedData = new ByteArrayOutputStream();
-    byte[] buffer = new byte[NativeGCMCipher.TAG_LENGTH / 6];
+    byte[] buffer = new byte[CryptoConfig.KEY_128.tagLength / 6];
     int read;
     while ((read = inputStream.read(buffer)) != -1) {
       assertTrue(read > 0);
@@ -225,7 +224,7 @@ public class NativeGCMCipherInputStreamTest extends InstrumentationTestCase {
     Entity entity = new Entity(CryptoTestUtils.ENTITY_NAME);
     byte[] aadData = CryptoSerializerHelper.computeBytesToAuthenticate(entity.getBytes(),
         VersionCodes.CIPHER_SERIALIZATION_VERSION,
-        VersionCodes.CIPHER_ID);
+            CryptoConfig.KEY_128.cipherId);
     BouncyCastleHelper.Result result = BouncyCastleHelper.bouncyCastleEncrypt(mData,
         mKey,
         mIV,

--- a/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/NativeGCMCipherOutputStreamTest.java
@@ -56,7 +56,7 @@ public class NativeGCMCipherOutputStreamTest extends InstrumentationTestCase {
     byte[] aadData = CryptoSerializerHelper.computeBytesToAuthenticate(
         entity.getBytes(),
         VersionCodes.CIPHER_SERIALIZATION_VERSION,
-        VersionCodes.CIPHER_ID);
+        CryptoConfig.KEY_128.cipherId);
     BouncyCastleHelper.Result result = BouncyCastleHelper.bouncyCastleEncrypt(mData,
         mKey,
         mIV,

--- a/instrumentTest/crypto/src/com/facebook/crypto/SimpleDecryptTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/SimpleDecryptTest.java
@@ -5,12 +5,12 @@ import android.os.Build;
 import android.test.InstrumentationTestCase;
 
 import com.facebook.android.crypto.keychain.AndroidConceal;
-import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.keychain.KeyChain;
 import com.facebook.crypto.util.NativeCryptoLibrary;
-import com.facebook.crypto.util.SystemNativeCryptoLibrary;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 
 @TargetApi(Build.VERSION_CODES.GINGERBREAD)
@@ -53,15 +53,15 @@ public class SimpleDecryptTest extends InstrumentationTestCase {
   }
 
   public void testDecryptionFailsOnIncorrectTag() throws Exception {
-    byte[] fakeTag = new byte[NativeGCMCipher.TAG_LENGTH];
+    byte[] fakeTag = new byte[CryptoConfig.KEY_128.tagLength];
     Arrays.fill(fakeTag, (byte) CryptoTestUtils.KEY_BYTES);
 
     // Overwrite the tag bytes.
     System.arraycopy(fakeTag,
         0,
         mCipheredData,
-        mCipheredData.length - NativeGCMCipher.TAG_LENGTH,
-        NativeGCMCipher.TAG_LENGTH);
+        mCipheredData.length - CryptoConfig.KEY_128.tagLength,
+            CryptoConfig.KEY_128.tagLength);
     try {
       mCrypto.decrypt(mCipheredData, new Entity(CryptoTestUtils.ENTITY_NAME));
     } catch (IOException e) {
@@ -95,7 +95,7 @@ public class SimpleDecryptTest extends InstrumentationTestCase {
     Entity entity = new Entity(CryptoTestUtils.ENTITY_NAME);
     byte[] aadData = CryptoSerializerHelper.computeBytesToAuthenticate(entity.getBytes(),
         VersionCodes.CIPHER_SERIALIZATION_VERSION,
-        VersionCodes.CIPHER_ID);
+        CryptoConfig.KEY_128.cipherId);
     BouncyCastleHelper.Result result = BouncyCastleHelper.bouncyCastleEncrypt(mData,
         mKey,
         mIV,

--- a/instrumentTest/crypto/src/com/facebook/crypto/SimpleEncryptTest.java
+++ b/instrumentTest/crypto/src/com/facebook/crypto/SimpleEncryptTest.java
@@ -40,7 +40,7 @@ public class SimpleEncryptTest extends InstrumentationTestCase {
     byte[] aadData = CryptoSerializerHelper.computeBytesToAuthenticate(
         entity.getBytes(),
         VersionCodes.CIPHER_SERIALIZATION_VERSION,
-        VersionCodes.CIPHER_ID);
+        CryptoConfig.KEY_128.cipherId);
     BouncyCastleHelper.Result result = BouncyCastleHelper.bouncyCastleEncrypt(mData,
         mKey,
         mIV,

--- a/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
+++ b/java/com/facebook/android/crypto/keychain/SharedPrefsBackedKeyChain.java
@@ -10,15 +10,15 @@
 
 package com.facebook.android.crypto.keychain;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
 
+import com.facebook.crypto.Crypto;
+import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.keychain.KeyChain;
-import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.exception.KeyChainException;
 import com.facebook.crypto.mac.NativeMac;
 
@@ -41,6 +41,8 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   /* package */ static final String CIPHER_KEY_PREF = "cipher_key";
   /* package */ static final String MAC_KEY_PREF = "mac_key";
 
+  private final CryptoConfig mCryptoConfig;
+
   private final SharedPreferences mSharedPreferences;
   private final FixedSecureRandom mSecureRandom;
 
@@ -53,12 +55,13 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
   public SharedPrefsBackedKeyChain(Context context) {
     mSharedPreferences = context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
     mSecureRandom = new FixedSecureRandom();
+    mCryptoConfig = CryptoConfig.KEY_128;
   }
 
   @Override
   public synchronized byte[] getCipherKey() throws KeyChainException {
     if (!mSetCipherKey) {
-      mCipherKey = maybeGenerateKey(CIPHER_KEY_PREF, NativeGCMCipher.KEY_LENGTH);
+      mCipherKey = maybeGenerateKey(CIPHER_KEY_PREF, mCryptoConfig.keyLength);
     }
     mSetCipherKey = true;
     return mCipherKey;
@@ -75,7 +78,7 @@ public class SharedPrefsBackedKeyChain implements KeyChain {
 
   @Override
   public byte[] getNewIV() throws KeyChainException {
-    byte[] iv = new byte[NativeGCMCipher.IV_LENGTH];
+    byte[] iv = new byte[mCryptoConfig.ivLength];
     mSecureRandom.nextBytes(iv);
     return iv;
   }

--- a/java/com/facebook/crypto/CheckedKeyChain.java
+++ b/java/com/facebook/crypto/CheckedKeyChain.java
@@ -12,6 +12,7 @@ package com.facebook.crypto;
 
 import com.facebook.crypto.exception.KeyChainException;
 import com.facebook.crypto.keychain.KeyChain;
+import com.facebook.crypto.mac.NativeMac;
 
 /**
  * Wrapper implementation of KeyChain.
@@ -42,7 +43,7 @@ class CheckedKeyChain implements KeyChain {
   @Override
   public byte[] getMacKey() throws KeyChainException {
     byte[] result = mDelegate.getMacKey();
-    checkLength(result, mConfig.macLength, "Mac");
+    checkLength(result, NativeMac.KEY_LENGTH, "Mac");
     return result;
   }
 

--- a/java/com/facebook/crypto/Crypto.java
+++ b/java/com/facebook/crypto/Crypto.java
@@ -10,7 +10,6 @@
 
 package com.facebook.crypto;
 
-import com.facebook.crypto.cipher.NativeGCMCipher;
 import com.facebook.crypto.exception.CryptoInitializationException;
 import com.facebook.crypto.exception.KeyChainException;
 import com.facebook.crypto.keychain.KeyChain;
@@ -218,6 +217,6 @@ public class Crypto {
    * Ciphertext data size = Plaintext data + Cipher meta data.
    */
   /* package protected */ int getCipherMetaDataLength() {
-    return 2 + NativeGCMCipher.IV_LENGTH + NativeGCMCipher.TAG_LENGTH;
+    return mCryptoAlgo.getCipherMetaDataLength();
   }
 }

--- a/java/com/facebook/crypto/Crypto.java
+++ b/java/com/facebook/crypto/Crypto.java
@@ -33,9 +33,9 @@ public class Crypto {
   private final CryptoAlgo mCryptoAlgo;
 
   public Crypto(KeyChain keyChain, NativeCryptoLibrary nativeCryptoLibrary) {
-    mKeyChain = new CheckedKeyChain(keyChain, CryptoConfig.VERSION_1);
+    mKeyChain = new CheckedKeyChain(keyChain, CryptoConfig.KEY_128);
     mNativeCryptoLibrary = nativeCryptoLibrary;
-    mCryptoAlgo = new CryptoAlgoV1(mNativeCryptoLibrary, mKeyChain);
+    mCryptoAlgo = new CryptoAlgoGcm(mNativeCryptoLibrary, mKeyChain);
   }
 
   /**

--- a/java/com/facebook/crypto/CryptoAlgo.java
+++ b/java/com/facebook/crypto/CryptoAlgo.java
@@ -20,4 +20,5 @@ public interface CryptoAlgo {
             throws IOException, CryptoInitializationException, KeyChainException;
     InputStream wrap(InputStream is, Entity entity)
             throws IOException, CryptoInitializationException, KeyChainException;
+    int getCipherMetaDataLength();
 }

--- a/java/com/facebook/crypto/CryptoAlgoGcm.java
+++ b/java/com/facebook/crypto/CryptoAlgoGcm.java
@@ -16,17 +16,16 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * Implements version 1 of cipher.
- * Uses unpadded GCM (128-bits key + 96-bits IV).
- * It includes final AAD.
- * This is the default implementation up to Conceal 1.0.5 (Conceal.getCrypto(KeyChain)).
+ * Implements GCM cipher.
+ * Uses unpadded GCM (128-bits key + 96-bits IV). It includes final AAD.
+ * This is the default implementation up to Conceal 1.0.6 (Conceal.getCrypto(KeyChain)).
  */
-public class CryptoAlgoV1 implements CryptoAlgo {
+public class CryptoAlgoGcm implements CryptoAlgo {
 
     private final NativeCryptoLibrary mNativeLibrary;
     private final KeyChain mKeyChain;
 
-    public CryptoAlgoV1(NativeCryptoLibrary mNativeLibrary, KeyChain mKeyChain) {
+    public CryptoAlgoGcm(NativeCryptoLibrary mNativeLibrary, KeyChain mKeyChain) {
         this.mNativeLibrary = mNativeLibrary;
         this.mKeyChain = mKeyChain;
     }

--- a/java/com/facebook/crypto/CryptoAlgoV1.java
+++ b/java/com/facebook/crypto/CryptoAlgoV1.java
@@ -82,5 +82,4 @@ public class CryptoAlgoV1 implements CryptoAlgo {
         gcmCipher.updateAad(cipherIDBytes, 1);
         gcmCipher.updateAad(entityBytes, entityBytes.length);
     }
-
 }

--- a/java/com/facebook/crypto/CryptoConfig.java
+++ b/java/com/facebook/crypto/CryptoConfig.java
@@ -16,15 +16,17 @@ package com.facebook.crypto;
  */
 public enum CryptoConfig {
 
-    KEY_128(16, 12, 64); // used in Conceal v1
+    KEY_128((byte) 1, 16, 12, 16); // used in Conceal v1
 
+    public final byte cipherId;
     public final int keyLength;
     public final int ivLength;
-    public final int macLength;
+    public final int tagLength;
 
-    CryptoConfig(int keyLength, int ivLength, int macLength) {
+    CryptoConfig(byte chiperId, int keyLength, int ivLength, int tagLength) {
+        this.cipherId = chiperId;
         this.keyLength = keyLength;
         this.ivLength = ivLength;
-        this.macLength = macLength;
+        this.tagLength = tagLength;
     };
 }

--- a/java/com/facebook/crypto/CryptoConfig.java
+++ b/java/com/facebook/crypto/CryptoConfig.java
@@ -16,7 +16,7 @@ package com.facebook.crypto;
  */
 public enum CryptoConfig {
 
-    VERSION_1(16, 12, 64); // used in Conceal v1
+    KEY_128(16, 12, 64); // used in Conceal v1
 
     public final int keyLength;
     public final int ivLength;

--- a/java/com/facebook/crypto/VersionCodes.java
+++ b/java/com/facebook/crypto/VersionCodes.java
@@ -21,11 +21,6 @@ package com.facebook.crypto;
   public static final byte CIPHER_SERIALIZATION_VERSION = 1;
 
   /**
-   * Identifier for the cipher algorithm and the framing method used.
-   */
-  public static final byte CIPHER_ID = 1;
-
-  /**
    * Identifier for the mac serialization version.
    */
   public static final byte MAC_SERIALIZATION_VERSION = 1;

--- a/java/com/facebook/crypto/cipher/NativeGCMCipher.java
+++ b/java/com/facebook/crypto/cipher/NativeGCMCipher.java
@@ -11,6 +11,7 @@ package com.facebook.crypto.cipher;
 
 import java.util.Locale;
 
+import com.facebook.crypto.CryptoConfig;
 import com.facebook.crypto.exception.CryptoInitializationException;
 import com.facebook.crypto.util.Assertions;
 import com.facebook.crypto.util.NativeCryptoLibrary;
@@ -27,10 +28,6 @@ public class NativeGCMCipher {
   private static final String CIPHER_ALREADY_INIT = "Cipher has already been initialized";
   private static final String CIPHER_NOT_INIT = "Cipher has not been initialized";
   private static final String CIPHER_NOT_FINALIZED = "Cipher has not been finalized";
-
-  public static final int TAG_LENGTH = 16;
-  public static final int KEY_LENGTH = 16;
-  public static final int IV_LENGTH = 12;
 
   private STATE mCurrentState = STATE.UNINITIALIZED;
 

--- a/java/com/facebook/crypto/streams/NativeGCMCipherInputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherInputStream.java
@@ -36,8 +36,8 @@ public class NativeGCMCipherInputStream extends InputStream {
    * @param cipherDelegate The stream to read encrypted bytes from.
    * @param cipher The cipher used to decrypt the bytes.
    */
-  public NativeGCMCipherInputStream(InputStream cipherDelegate, NativeGCMCipher cipher) {
-    mCipherDelegate = new TailInputStream(cipherDelegate, NativeGCMCipher.TAG_LENGTH);
+  public NativeGCMCipherInputStream(InputStream cipherDelegate, NativeGCMCipher cipher, int tagLength) {
+    mCipherDelegate = new TailInputStream(cipherDelegate, tagLength);
     mCipher = cipher;
   }
 
@@ -105,7 +105,8 @@ public class NativeGCMCipherInputStream extends InputStream {
     // state and destroy it, so we should not execute this again.
     mTagChecked = true;
     try {
-      mCipher.decryptFinal(mCipherDelegate.getTail(), NativeGCMCipher.TAG_LENGTH);
+      byte[] tail = mCipherDelegate.getTail();
+      mCipher.decryptFinal(tail, tail.length);
     } finally {
       mCipher.destroy();
     }

--- a/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
+++ b/java/com/facebook/crypto/streams/NativeGCMCipherOutputStream.java
@@ -28,7 +28,7 @@ public class NativeGCMCipherOutputStream extends OutputStream {
   private final NativeGCMCipher mCipher;
   private final int mUpdateBufferChunkSize;
   private final byte[] mUpdateBuffer;
-  private final byte[] mTag = new byte[NativeGCMCipher.TAG_LENGTH];
+  private final byte[] mTag;
 
   private boolean mTagAppended = false;
 
@@ -41,9 +41,11 @@ public class NativeGCMCipherOutputStream extends OutputStream {
   public NativeGCMCipherOutputStream(
           OutputStream cipherDelegate,
           NativeGCMCipher cipher,
-          byte[] encryptBuffer) {
+          byte[] encryptBuffer,
+          int tagLength) {
     mCipherDelegate = cipherDelegate;
     mCipher = cipher;
+    mTag = new byte[tagLength];
 
     // use encryptBuffer or create a new one
     int cipherBlockSize = mCipher.getCipherBlockSize();

--- a/native/crypto/gcm_util.c
+++ b/native/crypto/gcm_util.c
@@ -20,7 +20,7 @@ const int GCM_DECRYPT_MODE = 0;
 static const char* JAVA_GCM_CLASS = "com/facebook/crypto/cipher/NativeGCMCipher";
 
 static const int GCM_KEY_LENGTH_IN_BYTES = 16;
-static const int GCM_IV_LENGTH_IN_BYTES = 16;
+static const int GCM_IV_LENGTH_IN_BYTES = 12;
 
 // Cache field id.
 static jfieldID fieldId = NULL;
@@ -38,14 +38,13 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
     return CRYPTO_FAILURE;
   }
 
-  jsize ivLength = (*env)->GetArrayLength(env, iv);
   jbyte* ivBytes = (*env)->GetByteArrayElements(env, iv, NULL);
   if (!ivBytes) {
     (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
     return CRYPTO_FAILURE;
   }
 
-  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes, ivLength);
+  GCM_JNI_CTX* ctx = Create_GCM_JNI_CTX(keyBytes, ivBytes);
   Set_GCM_JNI_CTX(env, obj, ctx);
 
   (*env)->ReleaseByteArrayElements(env, key, keyBytes, JNI_ABORT);
@@ -65,7 +64,7 @@ int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode)
   return CRYPTO_SUCCESS;
 }
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength) {
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes) {
   GCM_JNI_CTX* ctx = (GCM_JNI_CTX*) malloc(sizeof(GCM_JNI_CTX));
   if (!ctx) {
     return NULL;
@@ -92,17 +91,8 @@ GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength)
     return NULL;
   }
 
-  if (ivLength > GCM_IV_LENGTH_IN_BYTES) {
-    ivLength = GCM_IV_LENGTH_IN_BYTES;
-  }
-
   memcpy(ctx->key, keyBytes, GCM_KEY_LENGTH_IN_BYTES);
-  memcpy(ctx->iv, ivBytes, ivLength);
-  if (ivLength < GCM_IV_LENGTH_IN_BYTES) {
-    // pad IV with zeros if provided IV is smaller
-    // this will remove undefined behavior (which worked because the bytes were already the same)
-    memset(ctx->iv + ivLength, 0, GCM_IV_LENGTH_IN_BYTES - ivLength);
-  }
+  memcpy(ctx->iv, ivBytes, GCM_IV_LENGTH_IN_BYTES);
   return ctx;
 }
 

--- a/native/crypto/gcm_util.h
+++ b/native/crypto/gcm_util.h
@@ -17,7 +17,7 @@ void Init_GCM_CTX_Ptr_Field(JNIEnv* env);
 
 int Init_GCM(JNIEnv* env, jobject obj, jbyteArray key, jbyteArray iv, jint mode);
 
-GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes, jsize ivLength);
+GCM_JNI_CTX* Create_GCM_JNI_CTX(jbyte* keyBytes, jbyte* ivBytes);
 
 GCM_JNI_CTX* Get_GCM_JNI_CTX(JNIEnv* env, jobject obj);
 


### PR DESCRIPTION
- Simplify fix for IV 16->12 bytes mismatch
- Use CryptoConfig to configure all cipher steps